### PR TITLE
Removed unnecessary constraints on ALSA's buffer

### DIFF
--- a/src/apulse-stream.c
+++ b/src/apulse-stream.c
@@ -160,7 +160,6 @@ int
 do_connect_pcm(pa_stream *s, snd_pcm_stream_t stream_direction)
 {
     snd_pcm_hw_params_t *hw_params;
-    snd_pcm_sw_params_t *sw_params;
     int dir;
     unsigned int rate;
     const char *dev_name;
@@ -177,35 +176,21 @@ do_connect_pcm(pa_stream *s, snd_pcm_stream_t stream_direction)
         break;
     }
 
+    // Prepare hw parameter space
     CHECK_A(snd_pcm_hw_params_malloc, (&hw_params));
     CHECK_A(snd_pcm_hw_params_any, (s->ph, hw_params));
+
+    // Set the bare-minimum parameters needed for ALSA to play PA's stream correctly
+    rate = s->ss.rate;
     CHECK_A(snd_pcm_hw_params_set_access, (s->ph, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED));
     CHECK_A(snd_pcm_hw_params_set_format, (s->ph, hw_params, pa_format_to_alsa(s->ss.format)));
     CHECK_A(snd_pcm_hw_params_set_rate_resample, (s->ph, hw_params, 1));
-    rate = s->ss.rate;
-    dir = 0;
     CHECK_A(snd_pcm_hw_params_set_rate_near, (s->ph, hw_params, &rate, &dir));
     CHECK_A(snd_pcm_hw_params_set_channels, (s->ph, hw_params, s->ss.channels));
 
-    unsigned int period_time = 20 * 1000;
-    dir = 1;
-    CHECK_A(snd_pcm_hw_params_set_period_time_near, (s->ph, hw_params, &period_time, &dir));
-    dir = -1;
-    snd_pcm_uframes_t period_size;
-    CHECK_A(snd_pcm_hw_params_get_period_size, (hw_params, &period_size, &dir));
-
-    unsigned int buffer_time = 4 * period_time;
-    dir = 1;
-    CHECK_A(snd_pcm_hw_params_set_buffer_time_near, (s->ph, hw_params, &buffer_time, &dir));
+    // Install this hw parameter space
     CHECK_A(snd_pcm_hw_params, (s->ph, hw_params));
     snd_pcm_hw_params_free(hw_params);
-
-    CHECK_A(snd_pcm_sw_params_malloc, (&sw_params));
-    CHECK_A(snd_pcm_sw_params_current, (s->ph, sw_params));
-    CHECK_A(snd_pcm_sw_params_set_avail_min, (s->ph, sw_params, period_size));
-    // no period event requested
-    CHECK_A(snd_pcm_sw_params, (s->ph, sw_params));
-    snd_pcm_sw_params_free(sw_params);
 
     CHECK_A(snd_pcm_prepare, (s->ph));
 


### PR DESCRIPTION
This may correct issues #14 and #26, and does at least fix an issue I was having while using the following `/etc/asound.conf`:
```
pcm.!default {
    type plug
    slave.pcm "asymed"
}

pcm.asymed {
    type asym
    playback.pcm "dmixer"
    capture.pcm "dsnoop"
}

pcm.dmixer  {
   type dmix
   ipc_key 1024
   slave {
      pcm "hw:Audio"
      format S32_LE
      period_time 0     # 20000
      period_size 1024  # 20000
      buffer_size 8192  # 80000

      rate 96000
   }
   bindings {
      0 0
      1 1
   }
}

ctl.dmixer {
   type plughw
   card Audio
}
```
Using this config, Skype would not play sound work under apulse, and the following would be spit into the console:
```
[apulse] [error] do_connect_pcm, snd_pcm_hw_params_get_period_size, Invalid argument
[apulse] [error] do_connect_pcm, snd_pcm_hw_params_get_period_size, Invalid argument
```
However, if the commented-out values for `period_time`, `period_size`, and `buffer_size` were used, everything would run fine, since these were equal to the hard-coded values.

Regardless, if I've understood ALSA's documentation correctly, this tweak shouldn't cause any other changes to the program's functionality, and should run fine on other machines.