### PR TITLE
Make sink volume a per-stream property

### DIFF
--- a/src/apulse-context.c
+++ b/src/apulse-context.c
@@ -300,7 +300,6 @@ pa_context_new_with_proplist(pa_mainloop_api *mainloop_api, const char *name, pa
     c->streams_ht = g_hash_table_new(g_direct_hash, g_direct_equal);
 
     for (uint32_t k = 0; k < PA_CHANNELS_MAX; k++) {
-        c->sink_volume[k] = PA_VOLUME_NORM;
         c->source_volume[k] = PA_VOLUME_NORM;
     }
 
@@ -342,12 +341,15 @@ pa_context_set_sink_input_mute(pa_context *c, uint32_t idx, int mute, pa_context
 static void
 pa_context_set_sink_input_volume_impl(pa_operation *op)
 {
-    memset(&op->c->sink_volume, 0, sizeof(op->c->sink_volume));
+    uint32_t idx = op->int_arg_1;
+    pa_stream *s = g_hash_table_lookup(op->c->streams_ht, GINT_TO_POINTER(idx));
+
+    memset(s->volume, 0, sizeof(s->volume));
 
     const uint32_t channels = MIN(op->pa_cvolume_arg_1.channels, PA_CHANNELS_MAX);
 
     for (uint32_t k = 0; k < channels; k++)
-        op->c->sink_volume[k] = op->pa_cvolume_arg_1.values[k];
+        s->volume[k] = op->pa_cvolume_arg_1.values[k];
 
     if (op->context_success_cb)
         op->context_success_cb(op->c, 1, op->cb_userdata);

--- a/src/apulse-stream.c
+++ b/src/apulse-stream.c
@@ -124,7 +124,7 @@ data_available_for_stream(pa_mainloop_api *a, pa_io_event *ioe, int fd, pa_io_ev
             size_t bytecnt = MIN(buf_size, frame_count * frame_size);
             bytecnt = ringbuffer_read(s->rb, buf, bytecnt);
 
-            pa_apply_volume_multiplier(buf, bytecnt, s->c->sink_volume, &s->ss);
+            pa_apply_volume_multiplier(buf, bytecnt, s->volume, &s->ss);
 
             if (bytecnt == 0) {
                 // application is not ready yet, play silence
@@ -775,6 +775,9 @@ pa_stream_new_with_proplist(pa_context *c, const char *name, const pa_sample_spe
 
     s->rb = ringbuffer_new(72 * 1024);    // TODO: figure out size
     s->peek_buffer = malloc(s->rb->end - s->rb->start);
+
+    for (uint32_t k = 0; k < PA_CHANNELS_MAX; k++)
+        s->volume[k] = PA_VOLUME_NORM;
 
     return s;
 }

--- a/src/apulse.h
+++ b/src/apulse.h
@@ -46,7 +46,6 @@ struct pa_context {
     int                     next_stream_idx;
     GHashTable             *streams_ht;
     pa_volume_t             source_volume[PA_CHANNELS_MAX];
-    pa_volume_t             sink_volume[PA_CHANNELS_MAX];
 };
 
 struct pa_io_event {
@@ -114,6 +113,7 @@ struct pa_stream {
     size_t                  peek_buffer_data_len;
     void                   *write_buffer;
     volatile int            paused;
+    pa_volume_t             volume[PA_CHANNELS_MAX];
 };
 
 struct pa_operation {


### PR DESCRIPTION
This makes the "mute" button on each Firefox tab work separately.
The current behavior is that muting one tab mutes them all; this patch fixes this.

Fixes #46.