### PR TITLE
Futureproof firefox rpath example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,10 @@ as usual, without helper script.
 For example, for Firefox it would be:
 
 ```
-# patchelf --set-rpath /usr/lib/apulse /usr/lib/firefox/libxul.so
+find /usr/lib/firefox -type f -exec bash -c 'file {} |grep ELF >/dev/null' \; -exec patchelf --set-rpath /usr/'$LIB'/apulse {} \;
 ```
 
-For some reason, it doesn't work if RPATH is set for `/usr/lib/firefox/firefox`
-itself, so some experiments are required to make it work.
+Firefox seems to check for pulse audio in more than one .so file; the above command will patch all ELF files in /usr/lib/firefox to use apulse instead of pulse audio.
 
 
 License


### PR DESCRIPTION
After a firefox upgrade, merely patching libxul.so was insufficient to
get apulse working on my machine.

In addition I use $LIB instead of lib so that the example can be used
unchanged for 32-bit applications on 64-bit hosts.

Also, since it uses find and file, it could theoretically be used to
patch an entire /usr tree safely.  Whether or not to recommend this in
the readme I leave up to future changes.