### PR TITLE
Fix spelling error

### DIFF
--- a/src/trace.c
+++ b/src/trace.c
@@ -440,7 +440,7 @@ trace_pa_sample_format_t_as_string(pa_sample_format_t sf)
         break;
 
     default:
-        fmt = "UNKNONW";
+        fmt = "UNKNOWN";
         break;
     }
 


### PR DESCRIPTION
Isn't it wonderful what mistakes can debianization find?

I: apulse: spelling-error-in-binary usr/lib/apulse/libpulse.so.0 UNKNONW UNKNOWN