### PR TITLE
"handle" SND_PCM_STATE_PRIVATE1

### DIFF
--- a/src/apulse-stream.c
+++ b/src/apulse-stream.c
@@ -147,6 +147,9 @@ data_available_for_stream(pa_mainloop_api *a, pa_io_event *ioe, int fd,
                     "SND_PCM_STATE_DISCONNECTED state. Giving up.",
                     s->name ? s->name : "", s->c->name ? s->c->name : "");
                 break;
+            default:
+                // avoid compiler warnings of unhandled (library-private) enum values
+                break;
             }
 
 #if HAVE_SND_PCM_AVAIL


### PR DESCRIPTION
This library-private PCM state used internally only (see
https://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html#ga61ac499cb3701ce536d4d83725908860).

This avoids the compiler warning "enumeration value ‘SND_PCM_STATE_PRIVATE1’ not handled
in switch [-Wswitch]" (gcc (GCC) 8.1.1 20180531)

*Edit*
BTW I just saw that this was reported already: Fixes #88