### PR TITLE
Enable optional SDK mode (install files required to build apps with apulse)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(apulse)
 cmake_minimum_required (VERSION 2.8)
+include(GNUInstallDirs)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -fPIC -fvisibility=hidden")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration")
@@ -74,10 +75,19 @@ target_link_libraries(pulse-simple ${SYMBOLMAP} trace-helper ${REQ_LIBRARIES})
 
 add_subdirectory(tests)
 
-set(APULSEPATH "${CMAKE_INSTALL_PREFIX}/lib/apulse" CACHE PATH "library installation directory")
+set(APULSEPATH "${CMAKE_INSTALL_LIBDIR}/apulse" CACHE PATH "library installation directory")
+
 set(APULSE_SEARCH_PATHS "${APULSEPATH}" CACHE PATH "directory list for LD_LIBRARY_PATH")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/apulse.template"
                "${CMAKE_CURRENT_BINARY_DIR}/apulse" @ONLY)
+if (${INSTALL_SDK})
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/libpulse.pc.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libpulse.pc" @ONLY)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/libpulse-simple.pc.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libpulse-simple.pc" @ONLY)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/libpulse-mainloop-glib.pc.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libpulse-mainloop-glib.pc" @ONLY)
+endif()
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/apulse" DESTINATION bin
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
@@ -86,4 +96,5 @@ install(FILES "${CMAKE_SOURCE_DIR}/man/apulse.1" DESTINATION share/man/man1)
 
 if (${INSTALL_SDK})
     install(DIRECTORY "${CMAKE_SOURCE_DIR}/3rdparty/pulseaudio-headers/pulse" DESTINATION include)
+    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig" DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,30 +75,31 @@ target_link_libraries(pulse-simple ${SYMBOLMAP} trace-helper ${REQ_LIBRARIES})
 
 add_subdirectory(tests)
 
+set(APULSE_SEARCH_PATHS "${APULSEPATH}" CACHE PATH "directory list for LD_LIBRARY_PATH")
+
 if (${INSTALL_SDK})
     set(APULSEPATH "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "library installation directory")
-else()
-    set(APULSEPATH "${CMAKE_INSTALL_LIBDIR}/apulse" CACHE PATH "library installation directory")
-endif()
 
-set(APULSE_SEARCH_PATHS "${APULSEPATH}" CACHE PATH "directory list for LD_LIBRARY_PATH")
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/apulse.template"
-               "${CMAKE_CURRENT_BINARY_DIR}/apulse" @ONLY)
-if (${INSTALL_SDK})
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/libpulse.pc.in"
                    "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libpulse.pc" @ONLY)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/libpulse-simple.pc.in"
                    "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libpulse-simple.pc" @ONLY)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/libpulse-mainloop-glib.pc.in"
                    "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libpulse-mainloop-glib.pc" @ONLY)
+else()
+    set(APULSEPATH "${CMAKE_INSTALL_LIBDIR}/apulse" CACHE PATH "library installation directory")
+
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/apulse.template"
+                   "${CMAKE_CURRENT_BINARY_DIR}/apulse" @ONLY)
 endif()
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/apulse" DESTINATION bin
-        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 install(TARGETS pulse-simple pulse pulse-mainloop-glib DESTINATION "${APULSEPATH}")
 install(FILES "${CMAKE_SOURCE_DIR}/man/apulse.1" DESTINATION share/man/man1)
 
 if (${INSTALL_SDK})
     install(DIRECTORY "${CMAKE_SOURCE_DIR}/3rdparty/pulseaudio-headers/pulse" DESTINATION include)
     install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig" DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+else()
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/apulse" DESTINATION bin
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,11 @@ target_link_libraries(pulse-simple ${SYMBOLMAP} trace-helper ${REQ_LIBRARIES})
 
 add_subdirectory(tests)
 
-set(APULSEPATH "${CMAKE_INSTALL_LIBDIR}/apulse" CACHE PATH "library installation directory")
+if (${INSTALL_SDK})
+    set(APULSEPATH "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "library installation directory")
+else()
+    set(APULSEPATH "${CMAKE_INSTALL_LIBDIR}/apulse" CACHE PATH "library installation directory")
+endif()
 
 set(APULSE_SEARCH_PATHS "${APULSEPATH}" CACHE PATH "directory list for LD_LIBRARY_PATH")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/apulse.template"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ else()
     include_directories(${PA_INCLUDE_DIRECTORIES})
 endif()
 
+set(INSTALL_SDK 0 CACHE BOOLEAN "Install SDK files to build applications with apulse (Pulse Audio headers and pkg-config files) instead of system ones")
+
 link_directories(${REQ_LIBRARY_DIRS})
 
 add_library(trace-helper STATIC
@@ -81,3 +83,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/apulse" DESTINATION bin
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 install(TARGETS pulse-simple pulse pulse-mainloop-glib DESTINATION "${APULSEPATH}")
 install(FILES "${CMAKE_SOURCE_DIR}/man/apulse.1" DESTINATION share/man/man1)
+
+if (${INSTALL_SDK})
+    install(DIRECTORY "${CMAKE_SOURCE_DIR}/3rdparty/pulseaudio-headers/pulse" DESTINATION include)
+endif()

--- a/pkgconfig/libpulse-mainloop-glib.pc.in
+++ b/pkgconfig/libpulse-mainloop-glib.pc.in
@@ -4,6 +4,6 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: libpulse-mainloop-glib
 Description: PulseAudio GLib 2.0 Main Loop Wrapper (apulse)
 Version: 5.0
-Libs: -L${libdir}/apulse -lpulse-mainloop-glib -pthread
+Libs: -L${libdir} -lpulse-mainloop-glib -pthread
 Cflags: -I${includedir}
 Requires: glib-2.0

--- a/pkgconfig/libpulse-mainloop-glib.pc.in
+++ b/pkgconfig/libpulse-mainloop-glib.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: libpulse-mainloop-glib
+Description: PulseAudio GLib 2.0 Main Loop Wrapper (apulse)
+Version: 5.0
+Libs: -L${libdir}/apulse -lpulse-mainloop-glib -pthread
+Cflags: -I${includedir}
+Requires: glib-2.0

--- a/pkgconfig/libpulse-simple.pc.in
+++ b/pkgconfig/libpulse-simple.pc.in
@@ -4,6 +4,6 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: libpulse-simple
 Description: PulseAudio Simplified Synchronous Client Interface (apulse)
 Version: 5.0
-Libs: -L${libdir}/apulse -lpulse-simple -pthread
+Libs: -L${libdir} -lpulse-simple -pthread
 Cflags: -I${includedir}
 Requires: glib-2.0

--- a/pkgconfig/libpulse-simple.pc.in
+++ b/pkgconfig/libpulse-simple.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL__LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: libpulse-simple
+Description: PulseAudio Simplified Synchronous Client Interface (apulse)
+Version: 5.0
+Libs: -L${libdir}/apulse -lpulse-simple -pthread
+Cflags: -I${includedir}
+Requires: glib-2.0

--- a/pkgconfig/libpulse.pc.in
+++ b/pkgconfig/libpulse.pc.in
@@ -4,6 +4,6 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: libpulse
 Description: PulseAudio Client Interface (apulse)
 Version: 5.0
-Libs: -L${libdir}/apulse -lpulse -pthread
+Libs: -L${libdir} -lpulse -pthread
 Cflags: -I${includedir}
 Requires: glib-2.0 alsa

--- a/pkgconfig/libpulse.pc.in
+++ b/pkgconfig/libpulse.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: libpulse
+Description: PulseAudio Client Interface (apulse)
+Version: 5.0
+Libs: -L${libdir}/apulse -lpulse -pthread
+Cflags: -I${includedir}
+Requires: glib-2.0 alsa


### PR DESCRIPTION
Hi!

These patches provide an optional SDK mode which allows to use apulse as PulseAudio replacement to _build_ and run applications without PA installed. I'm well aware that apulse was not designed to be a drop-in replacement of PA, but for applications it already supports this mode will allow to compile and use such applications without building and installing PA. This is especially important for users building software form source, e.g. Gentoo. Of course in this mode PA and apulse can't be installed at the same time.

In this mode:
- PA headers are installed
- pkg-config files are generated and installed
- shared libraries are installed to the standard libdir (/usr/lib{,32,64}) depending on a distro and an arch.
- apulse wrapper is disabled, since libraries are in their standard paths now.

It can be enabled with -DINSTALL_SDK and is disabled by default.