### PR TITLE
Use alsa API properly

### DIFF
--- a/src/apulse.h
+++ b/src/apulse.h
@@ -26,7 +26,7 @@
 
 #define _GNU_SOURCE
 #include "ringbuffer.h"
-#include <asoundlib.h>
+#include <alsa/asoundlib.h>
 #include <glib.h>
 #include <poll.h>
 #include <pthread.h>

--- a/src/util.h
+++ b/src/util.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <asoundlib.h>
+#include <alsa/asoundlib.h>
 #include <pulse/pulseaudio.h>
 
 int


### PR DESCRIPTION
Consumers are expected to use <alsa/asoundlib.h> instead of
<asoundlib.h>.

This is in preparation of an change to pkgconfig(alsa) to
not pollute CFLAGS with -I/usr/include/alsa anymore

Signed-off-by: Olaf Hering <olaf@aepfle.de>