### PR TITLE
link libpulse-simple against libpulse to make apulse work for Unreal Engine 4 games

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,11 +64,12 @@ set_target_properties(pulse PROPERTIES VERSION 0)
 set_target_properties(pulse-mainloop-glib PROPERTIES VERSION 0)
 set_target_properties(pulse-simple PROPERTIES VERSION 0)
 
-set(SYMBOLMAP "-Wl,-version-script=\"${CMAKE_SOURCE_DIR}/src/symbolmap\"")
+set(CMAKE_SHARED_LINKER_FLAGS
+    "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-version-script=\"${CMAKE_SOURCE_DIR}/src/symbolmap\"")
 
-target_link_libraries(pulse ${SYMBOLMAP} trace-helper ${REQ_LIBRARIES})
-target_link_libraries(pulse-mainloop-glib ${SYMBOLMAP} trace-helper ${REQ_LIBRARIES})
-target_link_libraries(pulse-simple ${SYMBOLMAP} trace-helper ${REQ_LIBRARIES})
+target_link_libraries(pulse trace-helper ${REQ_LIBRARIES})
+target_link_libraries(pulse-mainloop-glib trace-helper ${REQ_LIBRARIES})
+target_link_libraries(pulse-simple trace-helper pulse ${REQ_LIBRARIES})
 
 add_subdirectory(tests)
 


### PR DESCRIPTION
Without this dlopen("libpulse-simple.so.0") will fail if the process
hasn't already loaded libpulse.so.0.