### PR TITLE
stream: Check the key before invoking g_hash_table_remove

### DIFF
--- a/src/apulse-stream.c
+++ b/src/apulse-stream.c
@@ -1019,7 +1019,11 @@ pa_stream_unref(pa_stream *s)
 
     s->ref_cnt--;
     if (s->ref_cnt == 0) {
-        g_hash_table_remove(s->c->streams_ht, GINT_TO_POINTER(s->idx));
+        GHashTable * __restrict const streams_ht =
+            s->c->streams_ht;
+        void const * key = GINT_TO_POINTER(s->idx);
+        if (key && g_hash_table_lookup(streams_ht, key))
+            g_hash_table_remove(streams_ht, key);
         ringbuffer_free(s->rb);
         free(s->peek_buffer);
         free(s->write_buffer);


### PR DESCRIPTION
Turns out that I hit a bug where `pa_stream_unref` would
call `g_hash_table_remove` with a NULL key.

Thanks for the lightweight and smooth error handling from
Glib, `g_hash_table_remove` generated an ABORT call, crashing
the Unity3D games (e.g. Wizards of Legend) I was trying to start.

Now, I discovered that `g_hash_table_lookup` CANNOT be called with a NULL
key. That also generate a crash... Ugh...

So, yeah, basically to avoid this bug, run the game and get some nice sound
in the headphones, here's what I did : 

* check that the key is not NULL (0)
* check that the key is actually inside the Hash table
* and THEN call g_hash_table_remove.

Note, here's my ~/.asoundrc, just in case :
```
defaults.pcm.!card Audio
defaults.ctl.!card Audio
```

**Audio** being a FiiO USB device where my headphones are connected to :
```
card 3: Audio [DigiHug USB Audio], device 0: USB Audio [USB Audio]
  Subdevices: 0/1
  Subdevice #0: subdevice #0
card 3: Audio [DigiHug USB Audio], device 1: USB Audio [USB Audio #1]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
```
Signed-off-by: Miouyouyou (Myy) <myy@miouyouyou.fr>